### PR TITLE
Configure Solr shared secret authentication for ACS-2566

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Back to [TAS Master Documentation](https://git.alfresco.com/tas/alfresco-tas-uti
     * [Configuration](#configuration)
     * [How to enable Test Rail Integration?](#how-to-enable-test-rail-integration)
 * [Reference](#reference)
-* [Change Log](docs/CHANGELOG.md) :glowing_star: 
+* [Change Log](docs/CHANGELOG.md) 🌟
 * [Contributors](#contributors)
 * [Releasing](#releasing)
 * [License](#license)

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <suiteXmlFile>src/main/resources/shared-resources/testCount.xml</suiteXmlFile>
         <maven.build.sourceVersion>11</maven.build.sourceVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tas.utility.version>3.0.47</tas.utility.version>
+        <tas.utility.version>3.0.48</tas.utility.version>
         <rest-assured.version>3.3.0</rest-assured.version>
         <httpclient-osgi-version>4.5.3</httpclient-osgi-version>
         <json-path.version>3.3.0</json-path.version>

--- a/src/main/java/org/alfresco/rest/core/RestWrapper.java
+++ b/src/main/java/org/alfresco/rest/core/RestWrapper.java
@@ -1129,6 +1129,20 @@ public class RestWrapper extends DSLWrapper<RestWrapper>
         this.serverURI = restProperties.envProperty().getSolrServerUrl();
         this.serverPort = restProperties.envProperty().getSolrPort();
         configureServerEndpoint();
+        configureSecretHeader();
+    }
+
+    /**
+     * Adds the secret Solr header if it has been set
+     */
+    private void configureSecretHeader()
+    {
+        String solrSecret = restProperties.envProperty().getSolrSecret();
+        if(!solrSecret.isEmpty())
+        {
+            String solrSecretName = restProperties.envProperty().getSolrSecretName();
+            configureRequestSpec().addHeader(solrSecretName, solrSecret);
+        }
     }
 
     /**


### PR DESCRIPTION
Conditionally add the Solr shared secret header to the RequestSpec defined for Solr endpoints.