### PR TITLE
ACS-2674 Add method to delete rendition

### DIFF
--- a/src/main/java/org/alfresco/rest/requests/Node.java
+++ b/src/main/java/org/alfresco/rest/requests/Node.java
@@ -591,6 +591,18 @@ public class Node extends ModelRequest<Node>
 
 
     /**
+     * Delete the rendition identified by renditionId using DELETE call on '/nodes/{nodeId}/renditions/{renditionId}
+     *
+     * @param renditionId id of rendition to delete
+     * @throws Exception
+     */
+    public void deleteNodeRendition(String renditionId) throws Exception
+    {
+        RestRequest request = RestRequest.simpleRequest(HttpMethod.DELETE, "nodes/{nodeId}/renditions/{renditionId}", repoModel.getNodeRef(), renditionId);
+        restWrapper.processEmptyModel(request);
+    }
+
+    /**
      * Get a node's children using GET call 'nodes/{nodeId}/children
      * 
      * @return a collection of nodes

--- a/src/main/java/org/alfresco/rest/requests/Node.java
+++ b/src/main/java/org/alfresco/rest/requests/Node.java
@@ -591,7 +591,7 @@ public class Node extends ModelRequest<Node>
 
 
     /**
-     * Delete the rendition identified by renditionId using DELETE call on '/nodes/{nodeId}/renditions/{renditionId}
+     * Delete the rendition identified by renditionId using DELETE call on "/nodes/{nodeId}/renditions/{renditionId}"
      *
      * @param renditionId id of rendition to delete
      * @throws Exception


### PR DESCRIPTION
This change will enable the use of endpoint to delete rendition.
[https://develop.envalfresco.com/api-explorer/#/renditions/deleteRendition](https://develop.envalfresco.com/api-explorer/#/renditions/deleteRendition)