### PR TITLE
Downgrade json-path and json-schema-validator to 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,9 @@
         <tas.utility.version>3.0.48</tas.utility.version>
         <rest-assured.version>3.3.0</rest-assured.version>
         <httpclient-osgi-version>4.5.13</httpclient-osgi-version>
-        <json-path.version>5.1.1</json-path.version>
+        <json-path.version>3.3.0</json-path.version>
         <xml-path.version>3.3.0</xml-path.version>
-        <json-schema-validator.version>5.1.1</json-schema-validator.version>
+        <json-schema-validator.version>3.3.0</json-schema-validator.version>
         <jackson-databind.version>2.13.3</jackson-databind.version>
         <maven-release.version>2.5.3</maven-release.version>
         <org.glassfish.version>1.1.4</org.glassfish.version>


### PR DESCRIPTION
This kind of partial upgrade to 5.1.1 for rest-assured components causes issue with mismatching groovy versions and overall failures across the board, eg.: https://app.travis-ci.com/github/Alfresco/alfresco-community-repo/jobs/573844815.

It's probably better to upgrade all at once, once (rest-assured to 5.1.1, along with xml-path, json-path, json-schema-validator etc.). Until then we'll have to revert this upgrade.