### PR TITLE
Downgrade httpclient-osgi to 4.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tas.utility.version>3.0.48</tas.utility.version>
         <rest-assured.version>3.3.0</rest-assured.version>
-        <httpclient-osgi-version>4.5.13</httpclient-osgi-version>
+        <httpclient-osgi-version>4.5.3</httpclient-osgi-version>
         <json-path.version>3.3.0</json-path.version>
         <xml-path.version>3.3.0</xml-path.version>
         <json-schema-validator.version>3.3.0</json-schema-validator.version>


### PR DESCRIPTION
The newer version of httpclient-osgi `4.5.13` causes this kind of failures: https://app.travis-ci.com/github/Alfresco/alfresco-community-repo/builds/252173415 on alfresco-community-repo REST TAS tests. We can temporarily downgrade this library to the previous version until we better figure out what's wrong with the upgrade.