### PR TITLE
ACS-3353: POST support for "other fields"

### DIFF
--- a/src/main/java/org/alfresco/rest/core/assertion/ModelAssertion.java
+++ b/src/main/java/org/alfresco/rest/core/assertion/ModelAssertion.java
@@ -125,7 +125,8 @@ public class ModelAssertion<T>
 
     /**
      * Use this method for asserting whole model with different model object. Method allows to ignore particular fields during the comparison.
-     * For proper work model should override {@code toString()} and {@code equals()} methods.
+     *
+     * WARNING: For proper work model should implement {@code toString()} and {@code equals()} methods.
      *
      * @param expected - expected model.
      * @param ignoreFields - fields which should be ignored during assertion.

--- a/src/main/java/org/alfresco/rest/core/assertion/ModelAssertion.java
+++ b/src/main/java/org/alfresco/rest/core/assertion/ModelAssertion.java
@@ -59,9 +59,9 @@ public class ModelAssertion<T>
             Assert.fail(String.format("Field {%s} was not found in returned response.",fieldNameToBeRetuned));
         }
     }
-    private final T model;
+    private final Object model;
 
-    public ModelAssertion(T model)
+    public ModelAssertion(Object model)
     {
         this.model = model;
     }
@@ -131,12 +131,13 @@ public class ModelAssertion<T>
      * @param ignoreFields - fields which should be ignored during assertion.
      * @return model.
      */
+    @SuppressWarnings("unchecked")
     public T isEqualTo(T expected, String... ignoreFields)
     {
-        T modelCopy = createCopyIgnoringFields(model, ignoreFields);
+        T modelCopy = createCopyIgnoringFields((T) model, ignoreFields);
         T expectedCopy = createCopyIgnoringFields(expected, ignoreFields);
         Assert.assertEquals(modelCopy, expectedCopy, String.format("Compared objects of type: %s are not equal!", model.getClass()));
-        return model;
+        return (T) model;
     }
 
     /**

--- a/src/main/java/org/alfresco/rest/core/assertion/ModelAssertion.java
+++ b/src/main/java/org/alfresco/rest/core/assertion/ModelAssertion.java
@@ -33,13 +33,15 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import io.restassured.path.json.JsonPath;
 import org.alfresco.utility.exception.TestConfigurationException;
 import org.alfresco.utility.model.TestModel;
 import org.testng.Assert;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.restassured.path.json.JsonPath;
 
 /**
  * Assertion on Rest Model
@@ -57,19 +59,20 @@ public class ModelAssertion<T>
             Assert.fail(String.format("Field {%s} was not found in returned response.",fieldNameToBeRetuned));
         }
     }
-    private Object model;
+    private final T model;
 
-    public ModelAssertion(Object model)
+    public ModelAssertion(T model)
     {
         this.model = model;
     }
 
     /**
      * Use this DSL for asserting particular fields of your model if your model
-     * is like this (basic POJO) public class Person extends
-     * ModelAssertion<Person> { private String id = "1234"; you can use assert
-     * the id of this person as:
-     * Person p = new Person(); p.assertField("id").is("1234")
+     * is like this (basic POJO)
+     * public class Person extends ModelAssertion<Person>
+     *     { private String id = "1234"; }
+     * you can use assert the id of this person as:
+     * Person p = new Person(); p.assertThat().field("id").is("1234")
      *
      * @param fieldName
      * @return
@@ -121,6 +124,22 @@ public class ModelAssertion<T>
     }
 
     /**
+     * Use this method for asserting whole model with different model object. Method allows to ignore particular fields during the comparison.
+     * For proper work model should override {@code toString()} and {@code equals()} methods.
+     *
+     * @param expected - expected model.
+     * @param ignoreFields - fields which should be ignored during assertion.
+     * @return model.
+     */
+    public T isEqualTo(T expected, String... ignoreFields)
+    {
+        T modelCopy = createCopyIgnoringFields(model, ignoreFields);
+        T expectedCopy = createCopyIgnoringFields(expected, ignoreFields);
+        Assert.assertEquals(modelCopy, expectedCopy, String.format("Compared objects of type: %s are not equal!", model.getClass()));
+        return model;
+    }
+
+    /**
      * Get all fields declared from all classes hierarchy
      *
      * @param fields
@@ -142,6 +161,18 @@ public class ModelAssertion<T>
         }
 
         return fields;
+    }
+
+    @SuppressWarnings("unchecked")
+    private T createCopyIgnoringFields(T model, String... ignoreFields)
+    {
+        Gson gson = new Gson();
+        JsonObject jsonObject = gson.fromJson(gson.toJson(model), JsonObject.class);
+        for (String ignoreField : ignoreFields)
+        {
+            jsonObject.remove(ignoreField);
+        }
+        return gson.fromJson(gson.toJson(jsonObject), (Class<? extends T>) model.getClass());
     }
 
     /**

--- a/src/main/java/org/alfresco/rest/model/RestActionBodyExecTemplateModel.java
+++ b/src/main/java/org/alfresco/rest/model/RestActionBodyExecTemplateModel.java
@@ -25,7 +25,7 @@
  */
 package org.alfresco.rest.model;
 
-import java.util.List;
+import java.util.Objects;
 
 import org.alfresco.rest.core.IRestModel;
 import org.alfresco.rest.core.assertion.ModelAssertion;
@@ -85,6 +85,29 @@ public class RestActionBodyExecTemplateModel extends TestModel implements IRestM
     public void setParams(Object params)
     {
         this.params = params;
-    }				
+    }
+
+    @Override
+    public String toString()
+    {
+        return "RestActionBodyExecTemplateModel{" + "actionDefinitionId='" + actionDefinitionId + '\'' + ", params=" + params + '}';
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        RestActionBodyExecTemplateModel that = (RestActionBodyExecTemplateModel) o;
+        return Objects.equals(actionDefinitionId, that.actionDefinitionId) && Objects.equals(params, that.params);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(actionDefinitionId, params);
+    }
 }
  

--- a/src/main/java/org/alfresco/rest/model/RestCompositeConditionDefinitionModel.java
+++ b/src/main/java/org/alfresco/rest/model/RestCompositeConditionDefinitionModel.java
@@ -26,6 +26,7 @@
 package org.alfresco.rest.model;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.alfresco.rest.core.IRestModel;
 import org.alfresco.rest.core.assertion.ModelAssertion;
@@ -120,6 +121,31 @@ public class RestCompositeConditionDefinitionModel extends TestModel implements 
     public void setSimpleConditions(List<RestSimpleConditionDefinitionModel> simpleConditions)
     {
         this.simpleConditions = simpleConditions;
-    }				
+    }
+
+    @Override
+    public String toString()
+    {
+        return "RestCompositeConditionDefinitionModel{" + "inverted=" + inverted + ", booleanMode='" + booleanMode + '\'' + ", compositeConditions=" + compositeConditions
+            + ", simpleConditions=" + simpleConditions + '}';
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        RestCompositeConditionDefinitionModel that = (RestCompositeConditionDefinitionModel) o;
+        return inverted == that.inverted && Objects.equals(booleanMode, that.booleanMode) && Objects.equals(compositeConditions, that.compositeConditions) && Objects.equals(
+            simpleConditions, that.simpleConditions);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(inverted, booleanMode, compositeConditions, simpleConditions);
+    }
 }
  

--- a/src/main/java/org/alfresco/rest/model/RestRuleModel.java
+++ b/src/main/java/org/alfresco/rest/model/RestRuleModel.java
@@ -26,6 +26,7 @@
 package org.alfresco.rest.model;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.alfresco.rest.core.IRestModel;
 import org.alfresco.rest.core.assertion.ModelAssertion;
@@ -236,6 +237,33 @@ If the field is omitted then the rule will apply to all nodes.
     public void setActions(List<RestActionBodyExecTemplateModel> actions)
     {
         this.actions = actions;
-    }				
+    }
+
+    @Override
+    public String toString()
+    {
+        return "RestRuleModel{" + "id='" + id + '\'' + ", name='" + name + '\'' + ", description='" + description + '\'' + ", enabled=" + enabled + ", cascade=" + cascade
+            + ", asynchronous=" + asynchronous + ", errorScript='" + errorScript + '\'' + ", isShared=" + isShared + ", triggers=" + triggers + ", conditions=" + conditions
+            + ", actions=" + actions + '}';
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        RestRuleModel ruleModel = (RestRuleModel) o;
+        return enabled == ruleModel.enabled && cascade == ruleModel.cascade && asynchronous == ruleModel.asynchronous && Objects.equals(id, ruleModel.id) && name.equals(
+            ruleModel.name) && Objects.equals(description, ruleModel.description) && Objects.equals(errorScript, ruleModel.errorScript) && Objects.equals(
+            isShared, ruleModel.isShared) && Objects.equals(triggers, ruleModel.triggers) && Objects.equals(conditions, ruleModel.conditions) && actions.equals(ruleModel.actions);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(id, name, description, enabled, cascade, asynchronous, errorScript, isShared, triggers, conditions, actions);
+    }
 }
  

--- a/src/main/java/org/alfresco/rest/model/RestSimpleConditionDefinitionModel.java
+++ b/src/main/java/org/alfresco/rest/model/RestSimpleConditionDefinitionModel.java
@@ -25,7 +25,7 @@
  */
 package org.alfresco.rest.model;
 
-import java.util.List;
+import java.util.Objects;
 
 import org.alfresco.rest.core.IRestModel;
 import org.alfresco.rest.core.assertion.ModelAssertion;
@@ -128,6 +128,29 @@ Where a property is multivalued then the condition is true if it is satisfied by
     public void setParameter(String parameter)
     {
         this.parameter = parameter;
-    }				
+    }
+
+    @Override
+    public String toString()
+    {
+        return "RestSimpleConditionDefinitionModel{" + "field='" + field + '\'' + ", comparator='" + comparator + '\'' + ", parameter='" + parameter + '\'' + '}';
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        RestSimpleConditionDefinitionModel that = (RestSimpleConditionDefinitionModel) o;
+        return Objects.equals(field, that.field) && Objects.equals(comparator, that.comparator) && Objects.equals(parameter, that.parameter);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(field, comparator, parameter);
+    }
 }
  


### PR DESCRIPTION
- adding method `isEqualTo()` allowing assertion of whole model with a different model.