### PR TITLE
ACS-3595 Action params are a map of key-value pairs.

### DIFF
--- a/src/main/java/org/alfresco/rest/core/JsonBodyGenerator.java
+++ b/src/main/java/org/alfresco/rest/core/JsonBodyGenerator.java
@@ -30,6 +30,7 @@ import javax.json.JsonArrayBuilder;
 import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -261,12 +262,13 @@ public class JsonBodyGenerator
      * @param params
      * @return
      */
-    public static String executeActionPostBody(String actionDefinitionId, RepoTestModel targetNode, Map<String, String> params)
+    public static String executeActionPostBody(String actionDefinitionId, RepoTestModel targetNode, Map<String, Serializable> params)
     {
         JsonObjectBuilder objectBuilder = jsonBuilder().createObjectBuilder();
-        for(Map.Entry<String, String> param : params.entrySet())
+        for(Map.Entry<String, Serializable> param : params.entrySet())
         {
-            objectBuilder.add(param.getKey(), param.getValue());
+            addJsonValue(objectBuilder, param.getKey(), param.getValue());
+
         }
         JsonObject value = defineJSON()
                 .add("actionDefinitionId", actionDefinitionId)
@@ -274,7 +276,40 @@ public class JsonBodyGenerator
                 .add("params", objectBuilder).build();
         return value.toString();
     }
-    
+
+    /** Add a value to the JSON object. */
+    private static void addJsonValue(JsonObjectBuilder objectBuilder, String key, Serializable value)
+    {
+        if (value == null)
+        {
+            objectBuilder.add(key, JsonObject.NULL);
+        }
+        else if (value instanceof Boolean)
+        {
+            objectBuilder.add(key, (boolean) value);
+        }
+        else if (value instanceof String)
+        {
+            objectBuilder.add(key, (String) value);
+        }
+        else if (value instanceof Integer)
+        {
+            objectBuilder.add(key, (int) value);
+        }
+        else if (value instanceof Long)
+        {
+            objectBuilder.add(key, (long) value);
+        }
+        else if (value instanceof Double)
+        {
+            objectBuilder.add(key, (double) value);
+        }
+        else
+        {
+            throw new UnsupportedOperationException("Unable to add entry to JsonObject: {" + key + ": " + value + "}");
+        }
+    }
+
     /**
      * {
      * "actionDefinitionId": "check-out",

--- a/src/main/java/org/alfresco/rest/model/RestActionBodyExecTemplateModel.java
+++ b/src/main/java/org/alfresco/rest/model/RestActionBodyExecTemplateModel.java
@@ -25,6 +25,8 @@
  */
 package org.alfresco.rest.model;
 
+import java.io.Serializable;
+import java.util.Map;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -52,7 +54,7 @@ public class RestActionBodyExecTemplateModel extends TestModel implements IRestM
     @JsonProperty(required = true)    
     private String actionDefinitionId;	    
 
-    private Object params;	    
+    private Map<String, Serializable> params;
 
     public String getActionDefinitionId()
     {
@@ -64,12 +66,12 @@ public class RestActionBodyExecTemplateModel extends TestModel implements IRestM
         this.actionDefinitionId = actionDefinitionId;
     }				
 
-    public Object getParams()
+    public Map<String, Serializable> getParams()
     {
         return this.params;
     }
 
-    public void setParams(Object params)
+    public void setParams(Map<String, Serializable> params)
     {
         this.params = params;
     }

--- a/src/main/java/org/alfresco/rest/requests/Actions.java
+++ b/src/main/java/org/alfresco/rest/requests/Actions.java
@@ -25,6 +25,7 @@
  */
 package org.alfresco.rest.requests;
 
+import java.io.Serializable;
 import java.util.Map;
 
 import org.alfresco.rest.core.JsonBodyGenerator;
@@ -56,7 +57,7 @@ public class Actions extends ModelRequest<Actions>
     /**
      * Execute action with parameters using POST on '/action-executions'
      */
-    public JSONObject executeAction(String actionDefinitionId, RepoTestModel targetNode, Map<String, String> params)
+    public JSONObject executeAction(String actionDefinitionId, RepoTestModel targetNode, Map<String, Serializable> params)
     {
         String postBody = JsonBodyGenerator.executeActionPostBody(actionDefinitionId, targetNode, params);
         RestRequest request = RestRequest.requestWithBody(HttpMethod.POST, postBody, "action-executions");


### PR DESCRIPTION
Update existing implementation to use Serializable values, rather than Strings.